### PR TITLE
Post dotnetstandard cleanup

### DIFF
--- a/CallMeMaybe.UnitTests/CallMeMaybe.UnitTests.csproj
+++ b/CallMeMaybe.UnitTests/CallMeMaybe.UnitTests.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="FluentAssertions" Version="4.19.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.7.99" />
+    <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/CallMeMaybe.UnitTests/MaybeExtensionsTests.cs
+++ b/CallMeMaybe.UnitTests/MaybeExtensionsTests.cs
@@ -1,7 +1,11 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Linq.Expressions;
 using FluentAssertions;
+using Moq;
 using Xunit;
 
 namespace CallMeMaybe.UnitTests
@@ -68,6 +72,20 @@ namespace CallMeMaybe.UnitTests
         }
 
         [Fact]
+        public void QueryableFirstMaybeShouldNotInvokeIEnumerableInterface()
+        {
+            // Arrange
+            var mock = new Mock<QueryableMockBase<int>>(new[]{1}.AsQueryable()){CallBase = true};
+
+            // Act
+            mock.Object.FirstMaybe();
+
+            // Assert
+            mock.Verify(q => q.GetEnumerator(), Times.Never);
+            mock.Verify(q => q.Provider, Times.Once);
+        }
+
+        [Fact]
         public void TestSingleMaybe()
         {
             Assert.Equal(Maybe.From(1), new[] {1}.SingleMaybe());
@@ -102,6 +120,34 @@ namespace CallMeMaybe.UnitTests
         private string UseMaybe(Maybe<int> x)
         {
             return x.ToString();
+        }
+
+        /// <summary>
+        /// This wrapper class acts like the given IQueryable, but with virtual methods that can be
+        /// mocked.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        public abstract class QueryableMockBase<T> : IQueryable<T>
+        {
+            private readonly IQueryable<T> _data;
+
+            protected QueryableMockBase(IQueryable<T> data)
+            {
+                _data = data;
+            }
+
+            public virtual IEnumerator<T> GetEnumerator()
+            {
+                return _data.GetEnumerator();
+            }
+
+            public virtual Type ElementType => _data.ElementType;
+            public virtual Expression Expression => _data.Expression;
+            public virtual IQueryProvider Provider => _data.Provider;
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
         }
     }
 }

--- a/CallMeMaybe.UnitTests/MaybeExtensionsTests.cs
+++ b/CallMeMaybe.UnitTests/MaybeExtensionsTests.cs
@@ -16,7 +16,8 @@ namespace CallMeMaybe.UnitTests
         public void TestSelectManyIEnumerables()
         {
             var values = new int?[] {1, null, 3};
-            var values2 = values.SelectMany(i => Maybe.From(i));
+            var values2 = values.SelectMany(Maybe.From);
+            values2.Should().BeEquivalentTo(1, 3);
         }
 
         [Fact]

--- a/CallMeMaybe/CallMeMaybe.csproj
+++ b/CallMeMaybe/CallMeMaybe.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
+    <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CallMeMaybe/CallMeMaybe.nuspec
+++ b/CallMeMaybe/CallMeMaybe.nuspec
@@ -44,4 +44,10 @@ v 0.1 Alpha release. API subject to change.</releaseNotes>
     <file src=".\bin\Release\netstandard1.4\CallMeMaybe.dll" target="lib\netstandard1.4\CallMeMaybe.dll" />
     <file src=".\bin\Release\netstandard1.4\CallMeMaybe.xml" target="lib\netstandard1.4\CallMeMaybe.xml" />
   </files>
+  <dependencies>
+    <group targetFramework="netstandard1.4">
+      <dependency id="System.Diagnostics.Contracts" version="4.3.0"/>      
+      <dependency id="System.Linq.Queryable" version="4.3.0"/>
+    </group>
+  </dependencies>
 </package>

--- a/CallMeMaybe/Maybe.cs
+++ b/CallMeMaybe/Maybe.cs
@@ -60,7 +60,7 @@ namespace CallMeMaybe
         }
 
         /// <summary>
-        /// Implicitly casts a value of type <see cref="T"/> to a <see cref="Maybe{T}"/>
+        /// Implicitly casts a value of type <typeparamref name="T"/> to a <see cref="Maybe{T}"/>
         /// </summary>
         /// <param name="value">
         /// The value the <see cref="Maybe{T}"/> should contain. If null, the

--- a/CallMeMaybe/Maybe.cs
+++ b/CallMeMaybe/Maybe.cs
@@ -45,14 +45,7 @@ namespace CallMeMaybe
             _value = value;
         }
 
-        /// <summary>
-        /// Attempts to get the value.
-        /// </summary>
-        /// <param name="value">
-        /// An out parameter that will be set to the value inside this <see cref="Maybe{T}"/>
-        /// if it has one, or the default value for type <see cref="T"/> if not.
-        /// </param>
-        /// <returns>True if this <see cref="Maybe{T}"/> has a value, false otherwise.</returns>
+        /// <inheritdoc />
         bool IMaybe.TryGetValue(out object value)
         {
             value = _value;

--- a/CallMeMaybe/Maybe.cs
+++ b/CallMeMaybe/Maybe.cs
@@ -24,10 +24,7 @@ namespace CallMeMaybe
         /// <summary>
         /// Gets whether or not this <see cref="Maybe{T}"/> contains a value.
         /// </summary>
-        public bool HasValue
-        {
-            get { return _hasValue; }
-        }
+        public bool HasValue => _hasValue;
 
         /// <summary>
         /// Constructs a <see cref="Maybe{T}"/> that contains the given value, or
@@ -73,9 +70,8 @@ namespace CallMeMaybe
             if (typeof (T) == typeof (object) && value is IMaybe)
             {
                 var otherMaybe = (IMaybe) value;
-                object otherValue;
 
-                if (otherMaybe.TryGetValue(out otherValue))
+                if (otherMaybe.TryGetValue(out var otherValue))
                 {
                     value = (T) otherValue;
                 }
@@ -104,10 +100,7 @@ namespace CallMeMaybe
         /// <summary>
         /// Gets a <see cref="Maybe{T}"/> without a value.
         /// </summary>
-        public static Maybe<T> Not
-        {
-            get { return default (Maybe<T>); }
-        }
+        public static Maybe<T> Not => default (Maybe<T>);
 
         #region LINQ Methods
 
@@ -149,7 +142,7 @@ namespace CallMeMaybe
         {
             if (criteria == null)
             {
-                throw new ArgumentNullException("criteria");
+                throw new ArgumentNullException(nameof(criteria));
             }
             return _hasValue && criteria(_value) ? this : default(Maybe<T>);
         }
@@ -174,7 +167,7 @@ namespace CallMeMaybe
         {
             if (resultSelector == null)
             {
-                throw new ArgumentNullException("resultSelector");
+                throw new ArgumentNullException(nameof(resultSelector));
             }
 
             return _hasValue ? resultSelector(_value) : default(Maybe<TResult>);
@@ -209,11 +202,11 @@ namespace CallMeMaybe
         {
             if (otherSelector == null)
             {
-                throw new ArgumentNullException("otherSelector");
+                throw new ArgumentNullException(nameof(otherSelector));
             }
             if (resultSelector == null)
             {
-                throw new ArgumentNullException("resultSelector");
+                throw new ArgumentNullException(nameof(resultSelector));
             }
 
             if (_hasValue)
@@ -275,7 +268,7 @@ namespace CallMeMaybe
         {
             if (action == null)
             {
-                throw new ArgumentNullException("action");
+                throw new ArgumentNullException(nameof(action));
             }
             if (_hasValue)
             {
@@ -309,7 +302,7 @@ namespace CallMeMaybe
         {
             if (getValueIfNot == null)
             {
-                throw new ArgumentNullException("getValueIfNot");
+                throw new ArgumentNullException(nameof(getValueIfNot));
             }
             return _hasValue ? _value : getValueIfNot();
         }
@@ -378,9 +371,8 @@ namespace CallMeMaybe
             // Each different type of Maybe<T> will be different, even if they have the
             // same internal value. This is so we can maintain consistent behavior: users
             // are not expected to be casting Maybes as objects under normal circumstances.
-            if (obj is Maybe<T>)
+            if (obj is Maybe<T> maybeT)
             {
-                var maybeT = (Maybe<T>) obj;
                 // Leverage the == operator that we've defined explicitly below.
                 return maybeT == this;
             }
@@ -449,7 +441,7 @@ namespace CallMeMaybe
         {
             if (criteria == null)
             {
-                throw new ArgumentNullException("criteria");
+                throw new ArgumentNullException(nameof(criteria));
             }
             return Where(criteria).HasValue;
         }
@@ -630,7 +622,7 @@ namespace CallMeMaybe
         {
             if (valueIfTrue == null)
             {
-                throw new ArgumentNullException("valueIfTrue");
+                throw new ArgumentNullException(nameof(valueIfTrue));
             }
             return condition ? From(valueIfTrue()) : Maybe<T>.Not;
         }

--- a/CallMeMaybe/MaybeExtensions.cs
+++ b/CallMeMaybe/MaybeExtensions.cs
@@ -175,10 +175,12 @@ namespace CallMeMaybe
         /// </returns>
         public static Maybe<T> FirstMaybe<T>(this IEnumerable<T> source)
         {
-            var enumerator = source.GetEnumerator();
-            return enumerator.MoveNext()
-                ? new Maybe<T>(enumerator.Current)
-                : new Maybe<T>(); 
+            using (var enumerator = source.GetEnumerator())
+            {
+                return enumerator.MoveNext()
+                    ? new Maybe<T>(enumerator.Current)
+                    : new Maybe<T>();
+            }
         }
 
 
@@ -231,10 +233,12 @@ namespace CallMeMaybe
         public static Maybe<T> FirstMaybe<T>(this IEnumerable<T?> source)
             where T : struct
         {
-            var enumerator = source.GetEnumerator();
-            return enumerator.MoveNext()
-                ? enumerator.Current.Maybe()
-                : new Maybe<T>();
+            using (var enumerator = source.GetEnumerator())
+            {
+                return enumerator.MoveNext()
+                    ? enumerator.Current.Maybe()
+                    : new Maybe<T>();
+            }
         }
 
         // Note: I've made a conscious decision not to implement a LastMaybe 
@@ -285,17 +289,19 @@ namespace CallMeMaybe
         /// </exception>
         public static Maybe<T> SingleMaybe<T>(this IEnumerable<T> source)
         {
-            var enumerator = source.GetEnumerator();
-            if (!enumerator.MoveNext())
+            using (var enumerator = source.GetEnumerator())
             {
-                return new Maybe<T>();
+                if (!enumerator.MoveNext())
+                {
+                    return new Maybe<T>();
+                }
+                T value = enumerator.Current;
+                if (enumerator.MoveNext())
+                {
+                    throw new InvalidOperationException("Sequence contains more than one element");
+                }
+                return value;
             }
-            T value = enumerator.Current;
-            if (enumerator.MoveNext())
-            {
-                throw new InvalidOperationException("Sequence contains more than one element");
-            }
-            return value;
         }
 
         /// <summary>
@@ -339,17 +345,19 @@ namespace CallMeMaybe
         public static Maybe<T> SingleMaybe<T>(this IEnumerable<T?> source)
             where T : struct
         {
-            var enumerator = source.GetEnumerator();
-            if (!enumerator.MoveNext())
+            using (var enumerator = source.GetEnumerator())
             {
-                return new Maybe<T>();
+                if (!enumerator.MoveNext())
+                {
+                    return new Maybe<T>();
+                }
+                T? value = enumerator.Current;
+                if (enumerator.MoveNext())
+                {
+                    throw new InvalidOperationException("Sequence contains more than one element");
+                }
+                return value.Maybe();
             }
-            T? value = enumerator.Current;
-            if (enumerator.MoveNext())
-            {
-                throw new InvalidOperationException("Sequence contains more than one element");
-            }
-            return value.Maybe();
         }
 
         // TODO: SumMaybe/MaxMaybe/MinMaybe methods

--- a/CallMeMaybe/MaybeExtensions.cs
+++ b/CallMeMaybe/MaybeExtensions.cs
@@ -31,8 +31,7 @@ namespace CallMeMaybe
             this IDictionary<TKey, TValue> dictionary,
             TKey key)
         {
-            TValue value;
-            if (dictionary.TryGetValue(key, out value))
+            if (dictionary.TryGetValue(key, out var value))
             {
                 return new Maybe<TValue>(value);
             }

--- a/CallMeMaybe/MaybeExtensions.cs
+++ b/CallMeMaybe/MaybeExtensions.cs
@@ -15,7 +15,7 @@ namespace CallMeMaybe
 
         /// <summary>
         /// Produces a <see cref="Maybe{T}"/> value that will contain the value corresponding 
-        /// to the given <see cref="key"/> in the dictionary if one exists, or which will be
+        /// to the given <paramref name="key"/> in the dictionary if one exists, or which will be
         /// empty otherwise.
         /// </summary>
         /// <typeparam name="TKey">The type of the source dictionary's key.</typeparam>
@@ -25,8 +25,8 @@ namespace CallMeMaybe
         /// <returns>
         /// A <see cref="Maybe{T}"/> that is empty if the given <paramref name="dictionary"/> 
         /// does not contain the given <paramref name="key"/></returns>, or if the value
-        /// with that <see cref="key"/> is null. Otherwise, the <see cref="Maybe{T}"/> will
-        /// contain the value with that <see cref="key"/>.
+        /// with that <paramref name="key"/> is null. Otherwise, the <see cref="Maybe{T}"/> will
+        /// contain the value with that <paramref name="key"/>.
         public static Maybe<TValue> GetMaybe<TKey, TValue>(
             this IDictionary<TKey, TValue> dictionary,
             TKey key)
@@ -367,7 +367,7 @@ namespace CallMeMaybe
         /// </summary>
         /// <typeparam name="T">The type of object the <see cref="Maybe{T}"/> will hold.</typeparam>
         /// <param name="nullable">A nullable object to convert to a <see cref="Maybe{T}"/></param>
-        /// <returns>A <see cref="Maybe{T}"/> that is empty if <see cref="nullable"/> does not have a value,
+        /// <returns>A <see cref="Maybe{T}"/> that is empty if <paramref name="nullable"/> does not have a value,
         /// or which contains the value if it does.</returns>
         /// <remarks>This is useful because nullables cannot be implicitly cast to <see cref="Maybe{T}"/>s,
         /// so we need an easy shortcut for passing a <see cref="Nullable{T}"/> into a method that
@@ -383,7 +383,7 @@ namespace CallMeMaybe
         /// </summary>
         /// <typeparam name="T">The type of object the <see cref="Nullable{T}"/> will hold.</typeparam>
         /// <param name="maybe">A nullable object to convert to a <see cref="Nullable{T}"/></param>
-        /// <returns>A <see cref="Nullable{T}"/> that is "null" if <see cref="maybe"/> does not have a value,
+        /// <returns>A <see cref="Nullable{T}"/> that is "null" if <paramref name="maybe"/> does not have a value,
         /// or which contains the value if it does.</returns>
         public static T? Nullable<T>(this Maybe<T> maybe) where T : struct
         {

--- a/CallMeMaybe/project.json
+++ b/CallMeMaybe/project.json
@@ -3,7 +3,8 @@
   "dependencies": {
     "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
     "NETStandard.Library": "1.6.0",
-    "System.Diagnostics.Contracts": "4.3.0"
+    "System.Diagnostics.Contracts": "4.3.0",
+    "System.Linq.Queryable": "4.3.0" 
   },
   "frameworks": {
     "netstandard1.4": {}

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<repositories>
-  <repository path="..\TestMeMaybe\packages.config" />
-</repositories>


### PR DESCRIPTION
Mostly fixes issue #15 but also improves C# 7 syntax, disposes enumerators, and improves xmldoc comments.